### PR TITLE
Fix privacy of JSONResponse struct

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,7 +1,7 @@
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JSONResponse<T> {
-    success: bool,
-    payload: T,
+    pub success: bool,
+    pub payload: T,
 }
 
 pub mod private;

--- a/tests/test_private_api.rs
+++ b/tests/test_private_api.rs
@@ -62,6 +62,9 @@ async fn test_account_status() {
     let result = bitso.get_account_status().await;
     assert!(result.is_ok());
     println!("{:?}", result);
+    // Test that the result's contents can be reached
+    let client_id = result.unwrap().payload.client_id;
+    assert_eq!(client_id, Some("1234".to_owned()));
 }
 
 /// Test successful request to get account balance


### PR DESCRIPTION
As pointed out by @mucinoab, the contents of the `JSONResponse` struct could not be accessed because they were private. This PR changes their privacy setting and adds a corresponding extension to the `test_account_status` to test that the code is working properly now.